### PR TITLE
Improve placement on the Workspace component

### DIFF
--- a/src/leerroutes/src/components/LeerrouteWorkspace.js
+++ b/src/leerroutes/src/components/LeerrouteWorkspace.js
@@ -26,6 +26,17 @@ export class LeerrouteWorkspace extends HTMLElement {
     setLeerrouteItems(leerrouteItems) {
         console.log("Received leerrouteItems:", leerrouteItems);
         this.leerrouteItems = leerrouteItems;
+
+        //Simplify links so we don't need to in test-site
+        this.leerrouteItems = leerrouteItems.map(item => {
+            const links = item.children.map(childId => ({
+                source: item.id,
+                target: childId,
+                value: 10
+            }));
+            return { ...item, links };
+        });
+
         this.updateWorkspace();
     }
 

--- a/src/leerroutes/src/components/LeerrouteWorkspace.js
+++ b/src/leerroutes/src/components/LeerrouteWorkspace.js
@@ -12,21 +12,32 @@ export class LeerrouteWorkspace extends HTMLElement {
     }
 
     render() {
-        const width = 928;
-        const height = 600;
+        const width = '100%';
+        const height = '100%';
         const color = d3.scaleOrdinal(d3.schemeCategory10);
+
+        // Create a container div for the simulation
+        const container = document.createElement('div');
+        container.style.width = width;
+        container.style.height = height;
+        this.shadowRoot.appendChild(container);
+
+        // Get the width and height of the container so we can calculate center
+        const containerWidth = container.clientWidth;
+        const containerHeight = container.clientHeight;
 
         // Simulation is essentially the workspace where all the nodes and links will appear
         const simulation = d3.forceSimulation(this.leerrouteItems)
-            .force("link", d3.forceLink(this.leerrouteItems.flatMap(d => d.links)).id(d => d.id).distance(250))
+            .force("link", d3.forceLink(this.leerrouteItems.flatMap(d => d.links)).id(d => d.id).distance(300))
             .force("charge", d3.forceManyBody())
-            .force("center", d3.forceCenter(width / 2, height / 2))
+            .force("center", d3.forceCenter(containerWidth / 2, containerHeight / 2))
             .on("tick", ticked);
 
-        // svg is used to display the nodes and links, the actual workspace
-        const svg = d3.select(this.shadowRoot)
+        // Append SVG to the container
+        const svg = d3.select(container)
             .append("svg")
-            .attr("style", "width: 100%; height: 100%;");
+            .attr("width", width)
+            .attr("height", height);
 
         // Links between nodes
         const link = svg.append("g")
@@ -58,7 +69,7 @@ export class LeerrouteWorkspace extends HTMLElement {
             .attr("fill", "#000")
             .style("font-size", "14px");
 
-        //A tick from the simulation
+        // A tick from the simulation
         function ticked() {
             link
                 .attr("x1", d => d.source.x)
@@ -68,30 +79,6 @@ export class LeerrouteWorkspace extends HTMLElement {
 
             node.attr("transform", d => `translate(${d.x},${d.y})`);
         }
-
-        //Drag events
-        node.call(d3.drag()
-            .on("start", dragstarted)
-            .on("drag", dragged)
-            .on("end", dragended));
-
-        function dragstarted(event) {
-            if (!event.active) simulation.alphaTarget(0.3).restart();
-            event.subject.fx = event.subject.x;
-            event.subject.fy = event.subject.y;
-        }
-
-        function dragged(event) {
-            event.subject.fx = event.x;
-            event.subject.fy = event.y;
-        }
-
-        function dragended(event) {
-            if (!event.active) simulation.alphaTarget(0);
-            event.subject.fx = null;
-            event.subject.fy = null;
-        }
-        // End Drag events
 
         simulation.on("end", () => {
             simulation.stop();

--- a/src/leerroutes/src/components/LeerrouteWorkspace.js
+++ b/src/leerroutes/src/components/LeerrouteWorkspace.js
@@ -23,7 +23,7 @@ export class LeerrouteWorkspace extends HTMLElement {
         }
     }
 
-    setLeerrouteItems(leerrouteItems) {
+    setLeerrouteItems(leerrouteItems, groupPositions) {
         console.log("Received leerrouteItems:", leerrouteItems);
         this.leerrouteItems = leerrouteItems;
 
@@ -35,6 +35,21 @@ export class LeerrouteWorkspace extends HTMLElement {
                 value: 10
             }));
             return { ...item, links };
+        });
+
+        // Calculate positions for each node based on group and position, fx and fy are fixed
+        this.leerrouteItems.forEach(item => {
+            const groupPosition = groupPositions[item.groupPosition];
+            if (groupPosition) {
+                item.fx = groupPosition.x;
+                item.fy = groupPosition.y + (groupPosition.offsetY || 0);
+
+                if (!groupPosition.offsetY) {
+                    groupPosition.offsetY = 100; // Default offsetY
+                } else {
+                    groupPosition.offsetY += 100; // Increment offsetY for next item
+                }
+            }
         });
 
         this.updateWorkspace();

--- a/src/test-site/public/index.html
+++ b/src/test-site/public/index.html
@@ -23,17 +23,13 @@
     <script>
         const leerrouteWorkspace = document.getElementById('leerrouteWorkspace');
 
-        //TODO: Simplify
         const leerrouteItems = [
             //Propedeuse
             {
                 id: 'P',
                 group: 'propedeuse',
-                links: [
-                    { source: 'P', target: 'HCI', value: 10 },
-                    { source: 'P', target: 'BPM', value: 10 },
-                    { source: 'P', target: 'OOSDD', value: 10 },
-                    { source: 'P', target: 'MC', value: 10 },
+                children: [
+                    'HCI', 'BPM', 'OOSDD', 'MC'
                 ]
             },
 
@@ -41,34 +37,29 @@
             {
                 id: 'HCI',
                 group: 'group',
-                links: [
-                    { source: 'HCI', target: 'CAA', value: 10 },
-                    { source: 'HCI', target: 'DS', value: 10 },
+                children: [
+                    'CAA', 'DS'
                 ]
             },
             {
                 id: 'BPM',
                 group: 'group',
-                links: [
-                    { source: 'BPM', target: 'CAA', value: 10 },
-                    { source: 'BPM', target: 'DS', value: 10 },
-                    { source: 'BPM', target: 'UI', value: 10 },
+                children: [
+                    'CAA', 'DS', 'UI'
                 ]
             },
             {
                 id: 'OOSDD',
                 group: 'group',
-                links: [
-                    { source: 'OOSDD', target: 'DS', value: 10 },
-                    { source: 'OOSDD', target: 'UI', value: 10 },
-                    { source: 'OOSDD', target: 'WD', value: 10 },
+                children: [
+                    'DS', 'UI', 'WD'
                 ]
             },
             {
                 id: 'MC',
                 group: 'group',
-                links: [
-                    { source: 'MC', target: 'IOT', value: 10 },
+                children: [
+                    'IOT'
                 ]
             },
 
@@ -76,44 +67,36 @@
             {
                 id: 'CAA',
                 group: 'group',
-                links: [
-                    { source: 'CAA', target: 'AIS', value: 10 },
-                    { source: 'CAA', target: 'MIT', value: 10 },
-                    { source: 'CAA', target: 'DO', value: 10 },
+                children: [
+                    'AIS', 'MIT', 'DO'
                 ]
             },
             {
                 id: 'DS',
                 group: 'group',
-                links: [
-                    { source: 'DS', target: 'AIS', value: 10 },
-                    { source: 'DS', target: 'MIT', value: 10 },
-                    { source: 'DS', target: 'ML', value: 10 },
-                    { source: 'DS', target: 'QSD', value: 10 },
+                children: [
+                    'AIS', 'MIT', 'ML', 'QSD'
                 ]
             },
             {
                 id: 'UI',
                 group: 'group',
-                links: [
-                    { source: 'UI', target: 'MIT', value: 10 },
-                    { source: 'UI', target: 'UXD', value: 10 },
+                children: [
+                    'MIT', 'UXD'
                 ]
             },
             {
                 id: 'WD',
                 group: 'group',
-                links: [
-                    { source: 'WD', target: 'DO', value: 10 },
-                    { source: 'WD', target: 'QSD', value: 10 },
+                children: [
+                    'DO', 'QSD'
                 ]
             },
             {
                 id: 'IOT',
                 group: 'group',
-                links: [
-                    { source: 'IOT', target: 'QSD', value: 10 },
-                    { source: 'IOT', target: 'CE', value: 10 },
+                children: [
+                    'QSD', 'CE'
                 ]
             },
 
@@ -121,51 +104,37 @@
             {
                 id: 'AIS',
                 group: 'ais',
-                links: [
-
-                ]
+                children: []
             },
             {
                 id: 'MIT',
                 group: 'mt',
-                links: [
-
-                ]
+                children: []
             },
             {
                 id: 'ML',
                 group: 'ml',
-                links: [
-
-                ]
+                children: []
             },
             {
                 id: 'UXD',
                 group: 'uxd',
-                links: [
-
-                ]
+                children: []
             },
             {
                 id: 'DO',
                 group: 'do',
-                links: [
-
-                ]
+                children: []
             },
             {
                 id: 'QSD',
                 group: 'qsd',
-                links: [
-
-                ]
+                children: []
             },
             {
                 id: 'CE',
                 group: 'ce',
-                links: [
-
-                ]
+                children: []
             },
         ];
 

--- a/src/test-site/public/index.html
+++ b/src/test-site/public/index.html
@@ -23,11 +23,21 @@
     <script>
         const leerrouteWorkspace = document.getElementById('leerrouteWorkspace');
 
+        //TODO: Make responsive based on window/viewport
+        const groupPositions = {
+            propedeuse: { x: 400, y: 400 },
+            secondRang: { x: 600, y: 250 },
+            thirdRang: { x: 850, y: 200 },
+            fourthRang: { x: 1200, y: 100 },
+        };
+
+        //Group is for colour from d3
         const leerrouteItems = [
             //Propedeuse
             {
                 id: 'P',
                 group: 'propedeuse',
+                groupPosition: 'propedeuse',
                 children: [
                     'HCI', 'BPM', 'OOSDD', 'MC'
                 ]
@@ -37,6 +47,7 @@
             {
                 id: 'HCI',
                 group: 'group',
+                groupPosition: 'secondRang',
                 children: [
                     'CAA', 'DS'
                 ]
@@ -44,6 +55,7 @@
             {
                 id: 'BPM',
                 group: 'group',
+                groupPosition: 'secondRang',
                 children: [
                     'CAA', 'DS', 'UI'
                 ]
@@ -51,6 +63,7 @@
             {
                 id: 'OOSDD',
                 group: 'group',
+                groupPosition: 'secondRang',
                 children: [
                     'DS', 'UI', 'WD'
                 ]
@@ -58,6 +71,7 @@
             {
                 id: 'MC',
                 group: 'group',
+                groupPosition: 'secondRang',
                 children: [
                     'IOT'
                 ]
@@ -67,6 +81,7 @@
             {
                 id: 'CAA',
                 group: 'group',
+                groupPosition: 'thirdRang',
                 children: [
                     'AIS', 'MIT', 'DO'
                 ]
@@ -74,6 +89,7 @@
             {
                 id: 'DS',
                 group: 'group',
+                groupPosition: 'thirdRang',
                 children: [
                     'AIS', 'MIT', 'ML', 'QSD'
                 ]
@@ -81,6 +97,7 @@
             {
                 id: 'UI',
                 group: 'group',
+                groupPosition: 'thirdRang',
                 children: [
                     'MIT', 'UXD'
                 ]
@@ -88,6 +105,7 @@
             {
                 id: 'WD',
                 group: 'group',
+                groupPosition: 'thirdRang',
                 children: [
                     'DO', 'QSD'
                 ]
@@ -95,6 +113,7 @@
             {
                 id: 'IOT',
                 group: 'group',
+                groupPosition: 'thirdRang',
                 children: [
                     'QSD', 'CE'
                 ]
@@ -104,41 +123,48 @@
             {
                 id: 'AIS',
                 group: 'ais',
+                groupPosition: 'fourthRang',
                 children: []
             },
             {
                 id: 'MIT',
                 group: 'mt',
+                groupPosition: 'fourthRang',
                 children: []
             },
             {
                 id: 'ML',
                 group: 'ml',
+                groupPosition: 'fourthRang',
                 children: []
             },
             {
                 id: 'UXD',
                 group: 'uxd',
+                groupPosition: 'fourthRang',
                 children: []
             },
             {
                 id: 'DO',
                 group: 'do',
+                groupPosition: 'fourthRang',
                 children: []
             },
             {
                 id: 'QSD',
                 group: 'qsd',
+                groupPosition: 'fourthRang',
                 children: []
             },
             {
                 id: 'CE',
                 group: 'ce',
+                groupPosition: 'fourthRang',
                 children: []
             },
         ];
 
-        leerrouteWorkspace.setLeerrouteItems(leerrouteItems);
+        leerrouteWorkspace.setLeerrouteItems(leerrouteItems, groupPositions);
     </script>
 </body>
 

--- a/src/test-site/public/index.html
+++ b/src/test-site/public/index.html
@@ -14,7 +14,7 @@
     </header>
     <main>
         <!-- Include the Leerroutes workspace element -->
-        <leerroute-workspace id="leerrouteWorkspace"></leerroute-workspace>
+        <leerroute-workspace id="leerrouteWorkspace" distance=300></leerroute-workspace>
     </main>
     <!-- Include the JavaScript file provided by Leerroutes package -->
     <script src="vendor/Leerroutes/dist/bundle.js"></script>


### PR DESCRIPTION
Issue: https://github.com/Windesheim-HBO-ICT/Leerroutes/issues/12

This PR improved on the following:
- Better handling of the workspace componente
   - Additional container so width and height can be `100%`
   - Creation function only gets called once
- Added distance attribute to component
- Remove drag events
- Simplified structure of items for linking
- Added groupPosition property so items can be positioned by group
   - Group property is used for colour and is from d3
- Position groups of items based on set x and y
   - Not yet responsive, is another issue. Only works on Desktop screens
- Added a docs folder to better explain the properties and usage of the component in the future    

Test-site now looks like this:
![test-site](https://github.com/Windesheim-HBO-ICT/Leerroutes/assets/16213031/41c22627-1192-4b8c-8dec-5cdfe5bcea32)

